### PR TITLE
feat: add first serial number input

### DIFF
--- a/src/Components/KeySubmissionForm/index.tsx
+++ b/src/Components/KeySubmissionForm/index.tsx
@@ -22,6 +22,7 @@ export const KeySubmissionForm = ({
     validFrom: string,
     validTill: string,
     distEnv: string,
+    serialNumber: string,
     singleQrPerPage?: boolean
   ) => void;
 }): React.ReactElement => {
@@ -30,6 +31,7 @@ export const KeySubmissionForm = ({
   const [validFrom, setValidFrom] = useState("");
   const [validTill, setValidTill] = useState("");
   const [distEnv, setDistEnv] = useState("");
+  const [serialNumber, setSerialNumber] = useState("");
   const [editableEndpoint, setEditableEndpoint] = useState(true);
   const [editableValidity, setEditableValidity] = useState(true);
   const [keys, setKeys] = useState<string[]>([]);
@@ -122,6 +124,10 @@ export const KeySubmissionForm = ({
           onChange={e => setDistEnv(e.target.value)}
         />
       </div>
+      <div className="mt-3">First Serial Number</div>
+      <div>
+        <input className="p-1" placeholder="1" value={serialNumber} onChange={e => setSerialNumber(e.target.value)} />
+      </div>
       <div className="mt-3">Print Settings</div>
       <div className="mt-1">
         <label className="bp3-control bp3-checkbox bp3-align-left">
@@ -136,7 +142,7 @@ export const KeySubmissionForm = ({
           text="Generate Printable Vouchers"
           onClick={() => {
             console.log(keys);
-            onKeySubmission(keys, endpoint, validFrom, validTill, distEnv, singleQrPerPage);
+            onKeySubmission(keys, endpoint, validFrom, validTill, distEnv, serialNumber, singleQrPerPage);
           }}
         />
       </div>

--- a/src/Components/VoucherList/index.tsx
+++ b/src/Components/VoucherList/index.tsx
@@ -2,14 +2,15 @@ import React, { useState } from "react";
 import { Voucher } from "../Voucher";
 import { KeySubmissionForm } from "../KeySubmissionForm";
 
-const startingSerial = 1;
-
 export const VoucherList = (): React.ReactElement => {
   const [keys, setKeys] = useState<string[]>([]);
   const [endpoint, setEndpoint] = useState("");
   const [validityPeriod, setValidityPeriod] = useState<{ from: string; till: string }>({ from: "", till: "" });
   const [singleQrPerPage, setSingleQrPerPage] = useState(false);
   const [distEnv, setDistEnv] = useState("");
+  const [serialNumber, setSerialNumber] = useState("");
+
+  const startingSerial = serialNumber !== "" ? parseInt(serialNumber) : 1;
 
   const onKeySubmission = (
     submittedKeys: string[],
@@ -17,6 +18,7 @@ export const VoucherList = (): React.ReactElement => {
     validFrom: string,
     validTill: string,
     distEnv: string,
+    serialNumber: string,
     singleQrPerPage = false
   ): void => {
     setKeys(submittedKeys);
@@ -24,6 +26,7 @@ export const VoucherList = (): React.ReactElement => {
     setValidityPeriod({ from: validFrom, till: validTill });
     setSingleQrPerPage(singleQrPerPage);
     setDistEnv(distEnv);
+    setSerialNumber(serialNumber);
   };
 
   const hasKeys = keys && keys.length > 0;


### PR DESCRIPTION
Allow additional input for first serial number. This is important when generating large numbers of vouchers, and might need to split up the generation. 